### PR TITLE
Fixing bugs in mp_tools

### DIFF
--- a/pydefect/cli/vasp/make_composition_energies_from_mp.py
+++ b/pydefect/cli/vasp/make_composition_energies_from_mp.py
@@ -35,10 +35,10 @@ def make_composition_energies_from_mp(elements: List[str],
 
     for e in entries:
         key = e.composition
-        energy = e.energy
+        energy = e.energy_per_atom
         for k, v in key.as_dict().items():
             energy += diff[k] * v
-        comp_es[key] = CompositionEnergy(energy, e.entry_id)
+        comp_es[key] = CompositionEnergy(energy, e.material_id)
     comp_es = remove_higher_energy_comp(comp_es)
     return CompositionEnergies(comp_es)
 

--- a/pydefect/util/mp_tools.py
+++ b/pydefect/util/mp_tools.py
@@ -4,15 +4,23 @@ from typing import List
 
 from pydefect.defaults import defaults
 from pymatgen.core import Element
-#from pymatgen.ext.matproj import MPRester, MPRestError
+
+# from pymatgen.ext.matproj import MPRester, MPRestError
 from mp_api.client import MPRester
 from vise.util.logger import get_logger
 from itertools import combinations, chain
+import json
+import os
 
 elements = [e.name for e in Element]
+cwd = os.path.dirname(os.path.realpath(__file__))
+mp_data_file =cwd +  "/MPID_elements_10th_Jan_2024.json"
 
+with open(mp_data_file, "r") as f:
+    mp_data = json.load(f)
 
 logger = get_logger(__name__)
+
 
 def exclude_rest_element(docs, element_list):
     final_materials = []
@@ -25,36 +33,98 @@ def exclude_rest_element(docs, element_list):
 
     return final_materials
 
+def get_compound_with_elist(element_list, mp_data_file=mp_data_file):
+    with open(mp_data_file, "r") as f:
+        mp_data = json.load(f)
+    selected = []
+    for key in mp_data.keys():
+        if set(mp_data[key]).issubset(set(element_list)):
+            selected.append(key)
+
+    return selected
+
 class MpQuery:
-    def __init__(self,
-                 element_list: List[str],
-                 e_above_hull: float = defaults.e_above_hull,
-                 properties: List[str] = None):
+    def __init__(
+        self,
+        element_list: List[str],
+        e_above_hull: float = defaults.e_above_hull,
+        properties: List[str] = None,
+    ):
         # API key is parsed via .pmgrc.yaml
         with MPRester() as m:
-            excluded = list(set(elements) - set(element_list))[:5]
-            logger.info("Note that you should use the newer MPRester with package mp-api!!")
-            default_fields = ["material_id", "formula_pretty", "structure",
-                              "symmetry", "band_gap", "total_magnetization",
-                              "types_of_magnetic_species","elements"]
+            excluded = list(set(elements) - set(element_list))
+            logger.info(
+                "Note that you should use the newer MPRester with package mp-api!!"
+            )
+            default_fields = [
+                "material_id",
+                "formula_pretty",
+                "structure",
+                "symmetry",
+                "band_gap",
+                "total_magnetization",
+                "types_of_magnetic_species",
+                "elements",
+            ]
             properties = properties or default_fields
-            materials = m.materials.summary.search(
-                #exclude_elements=excluded, # Currently Materials Project is not allowing excluding list longer than 15 character
-                energy_above_hull=(-1e-5, e_above_hull),
-                fields=properties)
-            #self.materials = materials # Uncomment this when above uncomment works and comment the bottom line
-            self.materials = exclude_rest_element(docs=materials, element_list=element_list)
+            # Adding following try and except to avoid error
+            # because currently materials project is not accepting
+            # excluded elements more than 15 character
+            try:
+                materials = m.materials.summary.search(
+                    exclude_elements=excluded,
+                    energy_above_hull=(-1e-5, e_above_hull),
+                    fields=properties,
+                )
+                self.materials = materials
+            except:
+                # Try screening from a local database to reduce load on materials project
+                try:
+                    selected_ids = get_compound_with_elist(element_list,mp_data_file=mp_data_file)
+                    materials = m.materials.summary.search(
+                        material_ids=selected_ids, energy_above_hull=(-1e-5, e_above_hull), fields=properties
+                        )
+                    self.materials = materials
+                except:
+                    materials = m.materials.summary.search(
+                        energy_above_hull=(-1e-5, e_above_hull), fields=properties
+                    )
+                    self.materials = exclude_rest_element(
+                    docs=materials, element_list=element_list
+                )
+
 
 class MpEntries:
-    def __init__(self,
-                 element_list: List[str],
-                 e_above_hull: float = defaults.e_above_hull,
-                 additional_properties: List[str] = None):
-        excluded = list(set(elements) - set(element_list))
-        criteria = ({"elements": {"$in": element_list, "$nin": excluded},
-                     "e_above_hull": {"$lte": e_above_hull}})
-        with MPRester() as m:
-            self.materials = m.get_entries(
-                criteria, property_data=additional_properties)
-
-
+   def __init__(
+       self,
+       element_list: List[str],
+       e_above_hull: float = defaults.e_above_hull,
+       additional_properties: List[str] = None,
+   ):
+       excluded = list(set(elements) - set(element_list))
+       criteria = {
+           "elements": {"$in": element_list, "$nin": excluded},
+           "e_above_hull": {"$lte": e_above_hull},
+       }
+       with MPRester() as m:
+           try:
+               materials = m.materials.summary.search(
+                   exclude_elements=excluded,
+                   energy_above_hull=(-1e-5, e_above_hull),
+                   fields=additional_properties,
+               )
+               self.materials = materials
+           except:
+               # Try screening from a local database to reduce load on materials project
+                try:
+                    selected_ids = get_compound_with_elist(element_list,mp_data_file=mp_data_file)
+                    materials = m.materials.summary.search(
+                        material_ids=selected_ids, energy_above_hull=(-1e-5, e_above_hull), fields=additional_properties
+                        )
+                    self.materials = materials
+                except:
+                    materials = m.materials.summary.search(
+                        energy_above_hull=(-1e-5, e_above_hull), fields=additional_properties
+                        )
+                    self.materials = exclude_rest_element(
+                        docs=materials, element_list=element_list)


### PR DESCRIPTION
I have changed some part of mp_tools.py. I am using the new version of MPRester from mp_api package. Also, now materials project is not allowing long list of exclude element feature while accessing through api. I have changed the MPQuery and MPEntries to fix this issue. To reduce the load on materials project, I have added a data file containing materials_id and element information.