### PR TITLE
Update orbital occupation weighting for localised orbitals

### DIFF
--- a/pydefect/analyzer/make_band_edge_states.py
+++ b/pydefect/analyzer/make_band_edge_states.py
@@ -69,10 +69,10 @@ def get_localized_orbs(orb_info_by_spin: List[List[OrbitalInfo]],
             for elem, contrb in orb.orbitals.items():
                 for y, c in enumerate(contrb):
                     try:
-                        orbs[elem][y] += c
+                        orbs[elem][y] += c*w
                     except IndexError:
                         orbs[elem].append(0.0)
-                        orbs[elem][y] += c
+                        orbs[elem][y] += c*w
 
         result.append(LocalizedOrbital(
             band_idx=i,


### PR DESCRIPTION
Hi!
Thanks again for developing such a powerful and useful defects code!

I noticed when using `pydefect` to get the band edge info for some [extrinsic defects in Se](https://chemrxiv.org/engage/chemrxiv/article-details/6706a93612ff75c3a1f8c995), it was showing localized orbital occupations greater than 1, while this is never seen for the band edge states as expected:
```
Sb_Se_+2
   INFO: The eigenvalues are shifted by -2.28
 -- band-edge states info
Spin-up
     Index  Energy  P-ratio  Occupation  OrbDiff  Orbitals                K-point coords
VBM  483    2.412   0.11     0.38        0.06     Se-p: 0.58              ( 0.500,  0.000,  0.500)
CBM  489    4.099   0.05     0.00        0.05     Se-s: 0.10, Se-p: 0.44  ( 0.000,  0.000,  0.500)
vbm has acceptor phs: False (0.153 vs. 0.2)
cbm has donor phs: False (0.000 vs. 0.2)
---
Localized Orbital(s)
Index  Energy  P-ratio  Occupation  Orbitals
484    2.467   0.26     0.15        Sb-s: 0.16, Sb-p: 0.26, Se-s: 0.25, Se-p: 4.36
485    3.642   0.05     0.00        Sb-p: 0.12, Se-s: 0.46, Se-p: 3.76, Se-d: 0.22
486    3.648   0.05     0.00        Sb-p: 0.11, Se-s: 0.46, Se-p: 3.77, Se-d: 0.22
487    4.063   0.04     0.00        Se-s: 0.40, Se-p: 4.00, Se-d: 0.25
488    4.070   0.04     0.00        Se-s: 0.40, Se-p: 4.01, Se-d: 0.24
```

This is also seen in the `pydefect` tutorial here: https://chemrxiv.org/engage/chemrxiv/article-details/6706a93612ff75c3a1f8c995
<img width="732" alt="image" src="https://github.com/user-attachments/assets/4429a944-1d16-47ca-8d66-6976baed0317">

This tiny fix to include the k-point weights when summing occupations over all k-points for the localised states, fixes this issue:
```
Sb_Se_+2
   INFO: The eigenvalues are shifted by -2.28
 -- band-edge states info
Spin-up
     Index  Energy  P-ratio  Occupation  OrbDiff  Orbitals                K-point coords
VBM  483    2.412   0.11     0.38        0.06     Se-p: 0.58              ( 0.500,  0.000,  0.500)
CBM  489    4.099   0.05     0.00        0.05     Se-s: 0.10, Se-p: 0.44  ( 0.000,  0.000,  0.500)
vbm has acceptor phs: False (0.153 vs. 0.2)
cbm has donor phs: False (0.000 vs. 0.2)
---
Localized Orbital(s)
Index  Energy  P-ratio  Occupation  Orbitals
484    2.467   0.26     0.15        Se-p: 0.54
485    3.642   0.05     0.00        Se-p: 0.47
486    3.648   0.05     0.00        Se-p: 0.47
487    4.063   0.04     0.00        Se-p: 0.50
488    4.070   0.04     0.00        Se-p: 0.50
```
(which is a more reasonable output)

From the code that I updated, it seems it was always the intent to use the weights `w` as this variable is taken in the loop, but then was never used in the addition of occupation values. For the perfect band edge states, this issue is avoided as the info is only taken at one k-point.