### PR TITLE
Minor refactoring to ensure full compatibility with `pymatgen-core` (only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Installation instructions
 1. Requirements
   - Python 3.7 or higher
   - vise
-  - pymatgen
+  - pymatgen-core
   - see requirements.txt for others
   
 

--- a/pydefect/cli/vasp/make_composition_energies_from_mp.py
+++ b/pydefect/cli/vasp/make_composition_energies_from_mp.py
@@ -9,7 +9,7 @@ from pydefect.chem_pot_diag.chem_pot_diag import CompositionEnergy, \
     CompositionEnergies
 from pydefect.util.mp_tools import MpQuery
 from pymatgen.core import Composition
-from pymatgen.entries.computed_entries import ComputedEntry
+from pymatgen.core.entries import ComputedEntry
 from vise.atom_energies.atom_energy import mp_energies
 from vise.util.logger import get_logger
 

--- a/pydefect/tests/cli/test_main_functions.py
+++ b/pydefect/tests/cli/test_main_functions.py
@@ -261,7 +261,7 @@ def test_make_efnv_correction_from_vasp(mocker):
     mock_make_efnv.assert_called_with(
         mock_defect_entry.charge, mock_calc_results, mock_perfect_calc_results,
         mock_unitcell.dielectric_constant,
-        defect_region_radius=None,
+        defect_region=None,
         calc_all_sites=False)
     mock_efnv.to_json_file.assert_called_with(
         Path("Va_O1_2") / "correction.json")

--- a/pydefect/tests/cli/vasp/test_main_vasp_util_functions.py
+++ b/pydefect/tests/cli/vasp/test_main_vasp_util_functions.py
@@ -90,8 +90,8 @@ def test_make_parchg_dir(tmpdir, mocker):
     assert Path("parchg/WAVECAR").read_text() == "d"
 
     actual = ViseIncar.from_file("parchg/INCAR")
-    expected = {"ALGO": "Normal", "LPARD": True, "LSEPB": True, "KPAR": 1,
-                "IBAND": "2 3"}
+    expected = {'ALGO': 'Normal', 'KPAR': 1, 'LPARD': True, 'IBAND': [2, 3],
+                'LSEPB': True}
     assert actual == expected
 
 

--- a/pydefect/tests/cli/vasp/test_make_composition_energies_from_mp.py
+++ b/pydefect/tests/cli/vasp/test_make_composition_energies_from_mp.py
@@ -7,7 +7,7 @@ from pydefect.chem_pot_diag.chem_pot_diag import CompositionEnergy, \
 from pydefect.cli.vasp.make_composition_energies_from_mp import \
     make_composition_energies_from_mp, remove_higher_energy_comp
 from pymatgen.core import Composition, Element
-from pymatgen.entries.computed_entries import ComputedEntry
+from pymatgen.core.entries import ComputedEntry
 
 
 @pytest.fixture

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 monty
-pymatgen
+pymatgen-core
 vise
 tabulate
 adjustText

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,6 @@ module_dir = os.path.dirname(os.path.abspath(__file__))
 reqs_raw = open(os.path.join(module_dir, "requirements.txt")).read()
 reqs_list = [r.replace("==", "~=") for r in reqs_raw.split("\n")]
 
-#with open("README.md", "r") as fh:
-#    long_description = fh.read()
-
 setup(
     name='pydefect',
     version=__version__,


### PR DESCRIPTION
This PR introduces some minor refactoring so that `pydefect` is directly dependent on only `pymatgen-core` (https://github.com/materialsproject/pymatgen-core – recently separated from the full `pymatgen` package to reduce the package size and demarcate internally-maintained code from community-maintained code).