### PR TITLE
Fix MPDataDoc conversion function 

### DIFF
--- a/pydefect/cli/vasp/make_composition_energies_from_mp.py
+++ b/pydefect/cli/vasp/make_composition_energies_from_mp.py
@@ -10,12 +10,22 @@ from pydefect.chem_pot_diag.chem_pot_diag import CompositionEnergy, \
 from pydefect.util.mp_tools import MpQuery
 from pymatgen.core import Composition
 from pymatgen.core.entries import ComputedEntry
+from emmet.core.summary import MPDataDoc
 from vise.atom_energies.atom_energy import mp_energies
 from vise.util.logger import get_logger
 
 parent = Path(__file__).parent
 logger = get_logger(__name__)
 
+def make_computed_entry_from_MpQuery(materials: List[MPDataDoc]):
+    entries = []
+    for entry in materials:
+        composition = entry.composition
+        energy = entry.energy_per_atom * composition.num_atoms
+        entry_id = str(entry.material_id)
+        entries.append(ComputedEntry(composition=composition,
+                        energy=energy, entry_id=entry_id))
+    return entries
 
 def make_composition_energies_from_mp(elements: List[str],
                                       atom_energy_yaml: Optional[str] = None,
@@ -25,7 +35,9 @@ def make_composition_energies_from_mp(elements: List[str],
     When the atom_energy_yaml is provided, the total energies are aligned
     via atom energies.
     """
-    entries: List[ComputedEntry] = MpQuery(elements).materials
+    properties = ["material_id", "composition", "energy_per_atom"]
+    materials = MpQuery(elements, properties=properties).materials
+    entries: List[ComputedEntry] = make_computed_entries_from_MpQuer(materials)
     comp_es = {}
     if atom_energy_yaml:
         energies = loadfn(atom_energy_yaml)

--- a/pydefect/cli/vasp/make_composition_energies_from_mp.py
+++ b/pydefect/cli/vasp/make_composition_energies_from_mp.py
@@ -10,7 +10,7 @@ from pydefect.chem_pot_diag.chem_pot_diag import CompositionEnergy, \
 from pydefect.util.mp_tools import MpQuery
 from pymatgen.core import Composition
 from pymatgen.core.entries import ComputedEntry
-from emmet.core.summary import MPDataDoc
+from emmet.core.summary import SummaryDoc as MPDataDoc
 from vise.atom_energies.atom_energy import mp_energies
 from vise.util.logger import get_logger
 

--- a/pydefect/cli/vasp/make_composition_energies_from_mp.py
+++ b/pydefect/cli/vasp/make_composition_energies_from_mp.py
@@ -37,7 +37,7 @@ def make_composition_energies_from_mp(elements: List[str],
     """
     properties = ["material_id", "composition", "energy_per_atom"]
     materials = MpQuery(elements, properties=properties).materials
-    entries: List[ComputedEntry] = make_computed_entries_from_MpQuer(materials)
+    entries: List[ComputedEntry] = make_computed_entry_from_MpQuery(materials)
     comp_es = {}
     if atom_energy_yaml:
         energies = loadfn(atom_energy_yaml)

--- a/pydefect/cli/vasp/make_composition_energies_from_mp.py
+++ b/pydefect/cli/vasp/make_composition_energies_from_mp.py
@@ -17,7 +17,7 @@ from vise.util.logger import get_logger
 parent = Path(__file__).parent
 logger = get_logger(__name__)
 
-def make_computed_entry_from_MpQuery(materials: List[MPDataDoc]):
+def make_computed_entry_from_mp_query(materials: List[MPDataDoc]):
     entries = []
     for entry in materials:
         composition = entry.composition
@@ -37,7 +37,7 @@ def make_composition_energies_from_mp(elements: List[str],
     """
     properties = ["material_id", "composition", "energy_per_atom"]
     materials = MpQuery(elements, properties=properties).materials
-    entries: List[ComputedEntry] = make_computed_entry_from_MpQuery(materials)
+    entries: List[ComputedEntry] = make_computed_entry_from_mp_query(materials)
     comp_es = {}
     if atom_energy_yaml:
         energies = loadfn(atom_energy_yaml)

--- a/pydefect/util/mp_tools.py
+++ b/pydefect/util/mp_tools.py
@@ -22,7 +22,7 @@ class MpQuery:
             logger.info("Note that you're using the newer MPRester.")
             default_fields = ["material_id", "formula_pretty", "structure",
                               "symmetry", "band_gap", "total_magnetization",
-                              "types_of_magnetic_species"]
+                              "types_of_magnetic_species", "composition"]
             properties = properties or default_fields
             self.materials = m.materials.summary.search(
                 chemsys=chemsys(element_list),

--- a/pydefect/util/mp_tools.py
+++ b/pydefect/util/mp_tools.py
@@ -22,12 +22,13 @@ class MpQuery:
             logger.info("Note that you're using the newer MPRester.")
             default_fields = ["material_id", "formula_pretty", "structure",
                               "symmetry", "band_gap", "total_magnetization",
-                              "types_of_magnetic_species", "composition"]
+                              "types_of_magnetic_species"]
             properties = properties or default_fields
             self.materials = m.materials.summary.search(
                 chemsys=chemsys(element_list),
                 energy_above_hull=(-1e-5, e_above_hull),
                 fields=properties)
+            
 
 
 def chemsys(element_list: list):


### PR DESCRIPTION
Hi Prof. @yuuukuma,
While using the command:

```bash
pydefect_util cefm -a atom_energies.yaml -e Mg Al O
```

an error was encountered due to missing `composition` and `energy` attributes in the entries returned by `pydefect.util.mp_tools.MpQuery`.

The root cause of the issue is that `entries` in the function `make_composition_energies_from_mp` expects a list of `ComputedEntry` objects (`List[ComputedEntry]`), but instead receives a list of `MPDataDoc` objects. As a result, the required attributes (`composition` and `energy`) are not directly accessible.

To resolve this, a new helper function, `make_computed_entry_from_mp_query`, has been introduced. This function converts a list of `MPDataDoc` objects into a list of `ComputedEntry` objects by extracting the necessary fields, including:

* `composition`
* `energy`
* `material_id`

The `make_composition_energies_from_mp` function has been updated accordingly to use this conversion step before processing the entries.